### PR TITLE
Initial CI tests (currently Linux only)

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -2,9 +2,9 @@ name: Swift
 
 on:
   push:
-    branches: [master, ci-test]
+    branches: master
   pull_request:
-    branches: [master]
+    branches: master
 
 jobs:
   build-ironoxide-java:
@@ -40,7 +40,7 @@ jobs:
           name: libironoxide_shared
           path: target/debug/libironoxide_shared.so
 
-  build-ironoxide-swift:
+  test-ironoxide-swift:
     needs: build-ironoxide-java
     runs-on: ubuntu-18.04
     steps:


### PR DESCRIPTION
This checks out ironoxide-cpp and builds it, saving the `.so` and `generated` as artifacts.
It then checks out ironoxide-swift and downloads the artifacts to use for building/testing

Random info:
- I used `sed` to fix the paths in `ironoxide.h`.
- Currently builds ironoxide-java in debug because it saves ~7 minutes of compile time. This could be changed later
- Currently is only running on Linux because that's what I have experience making compile/run. Also, since this is a private repo, I didn't want to use up all of our Github Actions minutes on it.
- The swift tests aren't run in parallel because that suppresses the output of tests that pass
- I couldn't get setting `LD_LIBRARY_PATH` to work, so I move `libironoxide_shared.so` manually to the `.build` directory